### PR TITLE
feat:add pagination to works component

### DIFF
--- a/app/constants.tsx
+++ b/app/constants.tsx
@@ -1,0 +1,1 @@
+export const WORKS_PER_PAGE = 5;

--- a/app/section/work/index.tsx
+++ b/app/section/work/index.tsx
@@ -6,6 +6,8 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Animate } from "@/app/animation";
 import { workDetails } from "./workDetails";
 import PopUPWorkDetails from "@/app/components/popupWorkDetails";
+import Pagination from "./pagination";
+import { WORKS_PER_PAGE } from "@/app/constants";
 
 interface WorkDetail {
   title: string;
@@ -26,6 +28,10 @@ interface WorkDetail {
 const Works = () => {
   const [showPopup, setShowPopup] = useState(false);
   const [selectedWork, setSelectedWork] = useState<WorkDetail | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const worksPerPage = WORKS_PER_PAGE;
+  const totalPages = Math.ceil(workDetails.length / worksPerPage);
 
   const handleShowPopup = (work: WorkDetail) => {
     setSelectedWork(work);
@@ -36,6 +42,12 @@ const Works = () => {
     setShowPopup(false);
     setSelectedWork(null);
   };
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+  const indexOfLastWork = currentPage * worksPerPage;
+  const indexOfFirstWork = indexOfLastWork - worksPerPage;
+  const currentWorks = workDetails.slice(indexOfFirstWork, indexOfLastWork);
 
   return (
     <div className="section">
@@ -48,7 +60,7 @@ const Works = () => {
             Featured Works
           </h1>
           <div className="relative mx-auto px-4 z-10">
-            {workDetails.map((work, index) => (
+            {currentWorks.map((work, index) => (
               <Card
                 key={index}
                 className="overflow-hidden bg-[rgb(var(--foreground))] rounded-xl transition-all mb-12"
@@ -108,6 +120,14 @@ const Works = () => {
                 </CardContent>
               </Card>
             ))}
+
+            {totalPages > 1 && (
+              <Pagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={handlePageChange}
+              />
+            )}
           </div>
         </Animate.FadeDown>
       </div>

--- a/app/section/work/pagination/index.tsx
+++ b/app/section/work/pagination/index.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+const Pagination = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: PaginationProps) => {
+  return (
+    <div className="flex justify-center items-center mt-8">
+      <button
+        disabled={currentPage === 1}
+        onClick={() => onPageChange(currentPage - 1)}
+        className="p-2 rounded-full hover:bg-gray-200 disabled:opacity-50"
+      >
+        <ChevronLeft className="w-6 h-6" />
+      </button>
+
+      <span className="mx-4 text-lg font-medium">
+        {currentPage} / {totalPages}
+      </span>
+
+      <button
+        disabled={currentPage === totalPages}
+        onClick={() => onPageChange(currentPage + 1)}
+        className="p-2 rounded-full hover:bg-gray-200 disabled:opacity-50"
+      >
+        <ChevronRight className="w-6 h-6" />
+      </button>
+    </div>
+  );
+};
+
+export default Pagination;


### PR DESCRIPTION
###  Add Pagination to Featured `Works` Component

**Description:** This PR introduces a pagination system to the Works component, limiting the number of works displayed per page to 5. The pagination is fully responsive and adjusts well on both mobile and desktop views.

Key Changes:

- Implemented a new `Pagination` component that allows users to navigate between pages of works, with next/previous buttons and page numbers.
- Updated the `Works` component to slice the `workDetails` data and display only 5 works per page.
- Added state management for currentPage in the Works component to track the currently viewed page.
- Ensured mobile responsiveness for the pagination and work cards.
- Integrated the `Pagination` component only when more than 5 works exist.
- Kept existing functionality intact, including the popup for detailed work views.


**Testing:**

- Verified that the pagination correctly slices the work data and navigates between pages.
- Tested responsiveness across various screen sizes to ensure a consistent user experience on mobile devices.
- Ensured that the popup for each work still opens as expected.